### PR TITLE
verdi PR to formalize Azure changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,5 +12,5 @@ Create a base CentOS7 image as described [here](https://github.com/hysds/hysds-f
 As _root_ run:
 
 ```sh
-bash < <(curl -skL https://github.com/earthobservatory/puppet-verdi/raw/azure-beta1/install.sh)
+bash < <(curl -skL https://github.com/hysds/puppet-verdi/raw/azure/install.sh)
 ```

--- a/README.md
+++ b/README.md
@@ -3,13 +3,14 @@
 Puppet module to install all software needed to set up HySDS
 and verdi job workers.
 
-
 ## Prerequisites
+
 Create a base CentOS7 image as described [here](https://github.com/hysds/hysds-framework/wiki/Puppet-Automation#create-a-base-centos-7-image-for-installation-of-all-hysds-component-instances).
 
-
 ## Installation
+
 As _root_ run:
-```
-bash < <(curl -skL https://github.com/hysds/puppet-verdi/raw/master/install.sh)
+
+```sh
+bash < <(curl -skL https://github.com/earthobservatory/puppet-verdi/raw/azure-beta1/install.sh)
 ```

--- a/install.sh
+++ b/install.sh
@@ -7,7 +7,7 @@ cd $mods_dir
 # IMPORTANT: please edit this branch name to the version of the Azure         #
 #            adaptation that you want to install on every Puppet module       #
 ###############################################################################
-git_branch="azure-beta1"
+git_branch="azure"
 
 
 ##########################################
@@ -66,7 +66,7 @@ fi
 # export scientific_python puppet module
 ##########################################
 
-git_loc="${git_url}/earthobservatory/puppet-scientific_python"
+git_loc="${git_url}/hysds/puppet-scientific_python"
 mod_dir=$mods_dir/scientific_python
 site_pp=$mod_dir/site.pp
 
@@ -80,7 +80,7 @@ fi
 # export cloud_utils puppet module
 ##########################################
 
-git_loc="${git_url}/earthobservatory/puppet-cloud_utils"
+git_loc="${git_url}/hysds/puppet-cloud_utils"
 mod_dir=$mods_dir/cloud_utils
 site_pp=$mod_dir/site.pp
 
@@ -94,7 +94,7 @@ fi
 # export verdi puppet module
 ##########################################
 
-git_loc="${git_url}/earthobservatory/puppet-verdi"
+git_loc="${git_url}/hysds/puppet-verdi"
 mod_dir=$mods_dir/verdi
 site_pp=$mod_dir/site.pp
 

--- a/install.sh
+++ b/install.sh
@@ -3,6 +3,13 @@
 mods_dir=/etc/puppet/modules
 cd $mods_dir
 
+###############################################################################
+# IMPORTANT: please edit this branch name to the version of the Azure         #
+#            adaptation that you want to install on every Puppet module       #
+###############################################################################
+git_branch="azure-beta1"
+
+
 ##########################################
 # need to be root
 ##########################################
@@ -59,13 +66,13 @@ fi
 # export scientific_python puppet module
 ##########################################
 
-git_loc="${git_url}/hysds/puppet-scientific_python"
+git_loc="${git_url}/earthobservatory/puppet-scientific_python"
 mod_dir=$mods_dir/scientific_python
 site_pp=$mod_dir/site.pp
 
 # check that module is here; if not, export it
 if [ ! -d $mod_dir ]; then
-  $git_cmd clone $git_loc $mod_dir
+  $git_cmd clone -b $git_branch --single-branch $git_loc $mod_dir
 fi
 
 
@@ -73,13 +80,13 @@ fi
 # export cloud_utils puppet module
 ##########################################
 
-git_loc="${git_url}/hysds/puppet-cloud_utils"
+git_loc="${git_url}/earthobservatory/puppet-cloud_utils"
 mod_dir=$mods_dir/cloud_utils
 site_pp=$mod_dir/site.pp
 
 # check that module is here; if not, export it
 if [ ! -d $mod_dir ]; then
-  $git_cmd clone $git_loc $mod_dir
+  $git_cmd clone -b $git_branch --single-branch $git_loc $mod_dir
 fi
 
 
@@ -87,13 +94,13 @@ fi
 # export verdi puppet module
 ##########################################
 
-git_loc="${git_url}/hysds/puppet-verdi"
+git_loc="${git_url}/earthobservatory/puppet-verdi"
 mod_dir=$mods_dir/verdi
 site_pp=$mod_dir/site.pp
 
 # check that module is here; if not, export it
 if [ ! -d $mod_dir ]; then
-  $git_cmd clone $git_loc $mod_dir
+  $git_cmd clone -b $git_branch --single-branch $git_loc $mod_dir
 fi
 
 

--- a/lib/facter/azure_public_ipv4.rb
+++ b/lib/facter/azure_public_ipv4.rb
@@ -1,0 +1,6 @@
+# azure_public_ipv4.rb
+Facter.add("ec2_public_ipv4") do
+  setcode do
+    %x{curl -H Metadata:true "http://169.254.169.254/metadata/instance/network/interface/0/ipv4/ipaddress/0/publicip?api-version=2017-03-01&format=text"}.chomp
+  end
+end

--- a/templates/index.html
+++ b/templates/index.html
@@ -5,7 +5,7 @@
 <body>
 <h1>TOC for <%= @hostname %></h1>
 <ol>
-  <li><a href="http://<%= @ec2_public_ipv4 %>:8085">WebDAV</a></li>
+  <li><a href="http://<%= @azure_public_ipv4 %>:8085">WebDAV</a></li>
 </ol>
 </body>
 </html>

--- a/templates/install_hysds.sh
+++ b/templates/install_hysds.sh
@@ -93,6 +93,11 @@ cd $OPS/$PACKAGE
 pip install -U pyasn1
 pip install -U pyasn1-modules
 pip install -U python-dateutil
+pip install azure
+pip install msrest
+pip install msrestazure
+pip install azure-mgmt
+pip install azure-cli
 pip install -e .
 if [ "$?" -ne 0 ]; then
   echo "Failed to run 'pip install -e .' for $PACKAGE."


### PR DESCRIPTION
This PR formalizes changes changes made on the `earthobservatory/azure-beta1` branch to `hysds/azure` branch. Changes include:

- Edited README to install from `earthobservatory/azure-beta1`
- Added `lib/facter/azure_public_ipv4.rb` to automatically retrieve the public IP for the running instance for Azure instances
- Edited `templates/index.html` to use `azure_public_ipv4.rb` to retrieve the correct IP address
- Added installation of Azure related Python package in `templates/install_hysds.sh`
- Edited `install.sh` to use the `earthobservatory/azure-beta1` build chain for Puppet modules

**Warning to maintainers of `earthobservatory`: do NOT delete the `azure-beta1` branch!**