### PR TITLE
NSDS-1951: Refactor to auto build oraclelinux and centos7 docker images

### DIFF
--- a/build_docker.sh
+++ b/build_docker.sh
@@ -1,12 +1,17 @@
 #!/bin/bash
-if [ "$#" -ne 1 ]; then
-  echo "Enter tag as arg: $0 <tag>"
-  echo "e.g.: $0 20170620"
-  echo "e.g.: $0 latest"
+if [ "$#" -ne 7 ]; then
+  echo "Usage: $0 <tag> <github org> <github repo branch> <framework branch> <hysds release> <base image tag> <base branch>"
+  echo "e.g.: $0 20170620 hysds master develop v4.0.1-beta.7 latest develop"
+  echo "e.g.: $0 latest pymonger develop develop develop develop master"
   exit 1
 fi
 TAG=$1
-
+ORG=$2
+BRANCH=$3
+FRAMEWORK_BRANCH=$4
+HYSDS_RELEASE=$5
+BASE_IMAGE_TAG=$6
+BASE_BRANCH=$7
 
 # enable docker buildkit to allow build secrets
 export DOCKER_BUILDKIT=1
@@ -21,14 +26,17 @@ fi
 
 # build
 docker build --progress=plain --rm --force-rm \
-  -t hysds/verdi:${TAG} -f docker/Dockerfile --build-arg RELEASE=${TAG} \
+  -t hysds/pge-base:${TAG} -f docker/Dockerfile.pge-base \
+  --build-arg FRAMEWORK_BRANCH=${FRAMEWORK_BRANCH} \
+  --build-arg HYSDS_RELEASE=${HYSDS_RELEASE} \
+  --build-arg TAG=${BASE_IMAGE_TAG} \
+  --build-arg ORG=${ORG} \
+  --build-arg BRANCH=${BRANCH} \
+  --build-arg BASE_BRANCH=${BASE_BRANCH} \
   --secret id=git_oauth_token,src=$OAUTH_CFG . || exit 1
 docker system prune -f || :
 docker build --progress=plain --rm --force-rm \
-  -t hysds/pge-base:${TAG} -f docker/Dockerfile.pge-base \
-  --build-arg RELEASE=${TAG} --secret id=git_oauth_token,src=$OAUTH_CFG . || exit 1
-docker system prune -f || :
-docker build --progress=plain --rm --force-rm \
-  -t hysds/cuda-pge-base:${TAG} -f docker/Dockerfile.cuda-pge-base \
-  --build-arg RELEASE=${TAG} --secret id=git_oauth_token,src=$OAUTH_CFG . || exit 1
+  -t hysds/verdi:${TAG} -f docker/Dockerfile \
+  --build-arg TAG=${TAG} \
+  --secret id=git_oauth_token,src=$OAUTH_CFG . || exit 1
 docker system prune -f || :

--- a/build_docker_cuda.sh
+++ b/build_docker_cuda.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+if [ "$#" -ne 7 ]; then
+  echo "Usage: $0 <tag> <github org> <github repo branch> <framework branch> <hysds release> <base image tag> <base branch>"
+  echo "e.g.: $0 20170620 hysds master develop v4.0.1-beta.7 latest develop"
+  echo "e.g.: $0 latest pymonger develop develop develop develop master"
+  exit 1
+fi
+TAG=$1
+ORG=$2
+BRANCH=$3
+FRAMEWORK_BRANCH=$4
+HYSDS_RELEASE=$5
+BASE_IMAGE_TAG=$6
+BASE_BRANCH=$7
+
+
+# enable docker buildkit to allow build secrets
+export DOCKER_BUILDKIT=1
+
+
+# set oauth token to bypass github API rate limits
+OAUTH_CFG="$HOME/.git_oauth_token"
+if [ ! -e "$OAUTH_CFG" ]; then
+  touch $OAUTH_CFG # create empty creds file for unauthenticated builds
+fi
+
+
+# build
+docker build --progress=plain --rm --force-rm \
+  -t hysds/cuda-pge-base:${TAG} -f docker/Dockerfile.cuda-pge-base \
+  --build-arg FRAMEWORK_BRANCH=${FRAMEWORK_BRANCH} \
+  --build-arg HYSDS_RELEASE=${HYSDS_RELEASE} \
+  --build-arg TAG=${BASE_IMAGE_TAG} \
+  --build-arg ORG=${ORG} \
+  --build-arg BRANCH=${BRANCH} \
+  --build-arg BASE_BRANCH=${BASE_BRANCH} \
+  --secret id=git_oauth_token,src=$OAUTH_CFG . || exit 1
+docker system prune -f || :

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,55 +1,9 @@
 # syntax = docker/dockerfile:1.0-experimental
-FROM hysds/dev:latest
-
-# git url to hysds dev puppet module
-ENV GIT_URL https://github.com/hysds/puppet-verdi/raw/docker/install.sh
-
-# get release to install
-ARG RELEASE=develop
-
-# add latest repo version to invalidate cache
-ADD https://api.github.com/repos/hysds/puppet-verdi/git/refs/heads/docker version.json
-
-# provision via puppet
-RUN --mount=type=secret,id=git_oauth_token sudo cp /run/secrets/git_oauth_token $HOME/.git_oauth_token \
- && sudo chown ops:ops $HOME/.git_oauth_token \
- && set -ex \
- && sudo yum update -y \
- && sudo curl -skL ${GIT_URL} > /tmp/install.sh \
- && sudo chmod 755 /tmp/install.sh \
- && sudo /tmp/install.sh \
- && sudo rm -rf /etc/puppet/modules/* /mnt/swapfile \
- && sudo yum clean all \
- && sudo rm -f /tmp/install.sh \
- && sudo rm -rf /var/cache/yum \
- && cd $HOME \
- && ./install_hysds.sh ${RELEASE} \
- && rm -rf $HOME/verdi/ops/*/.git* \
- && rm -rf $HOME/.cache \
- && rm -rf $HOME/.git_oauth_token
-
-
-FROM hysds/base:latest
+ARG TAG=latest
+FROM hysds/pge-base:${TAG}
 
 MAINTAINER Gerald Manipon (pymonger) "pymonger@gmail.com"
 LABEL description="HySDS verdi image"
-
-# git url to hysds dev puppet module
-ENV GIT_URL https://github.com/hysds/puppet-verdi/raw/docker/install.sh
-
-# provision via puppet
-RUN set -ex \
- && sudo yum update -y \
- && sudo curl -skL ${GIT_URL} > /tmp/install.sh \
- && sudo chmod 755 /tmp/install.sh \
- && sudo /tmp/install.sh \
- && sudo rm -rf /etc/puppet/modules/* /mnt/swapfile \
- && sudo yum clean all \
- && sudo rm -f /tmp/install.sh \
- && sudo rm -rf /var/cache/yum
-
-# copy ops home
-COPY --chown=ops:ops --from=0 /home/ops /home/ops
 
 # link configs
 RUN set -ex \

--- a/docker/Dockerfile.cuda-pge-base
+++ b/docker/Dockerfile.cuda-pge-base
@@ -1,14 +1,21 @@
 # syntax = docker/dockerfile:1.0-experimental
-FROM hysds/cuda-dev:latest
+ARG TAG=latest
+FROM hysds/cuda-dev:${TAG}
 
-# git url to hysds dev puppet module
-ENV GIT_URL https://github.com/hysds/puppet-verdi/raw/docker/install.sh
+# get org and branch
+ARG ORG
+ARG BRANCH
+ARG FRAMEWORK_BRANCH
+ARG BASE_BRANCH
+
+# git url to hysds verdi puppet module
+ENV GIT_URL https://github.com/${ORG}/puppet-verdi/raw/${BRANCH}/install.sh
 
 # get release to install
-ARG RELEASE=develop
+ARG HYSDS_RELEASE=develop
 
 # add latest repo version to invalidate cache
-ADD https://api.github.com/repos/hysds/puppet-verdi/git/refs/heads/docker version.json
+ADD https://api.github.com/repos/${ORG}/puppet-verdi/git/refs/heads/${BRANCH} version.json
 
 # provision via puppet
 RUN --mount=type=secret,id=git_oauth_token sudo cp /run/secrets/git_oauth_token $HOME/.git_oauth_token \
@@ -17,32 +24,37 @@ RUN --mount=type=secret,id=git_oauth_token sudo cp /run/secrets/git_oauth_token 
  && sudo yum update -y \
  && sudo curl -skL ${GIT_URL} > /tmp/install.sh \
  && sudo chmod 755 /tmp/install.sh \
- && sudo /tmp/install.sh \
+ && sudo /tmp/install.sh ${ORG} ${BRANCH} ${BASE_BRANCH} \
  && sudo rm -rf /etc/puppet/modules/* /mnt/swapfile \
  && sudo yum clean all \
  && sudo rm -f /tmp/install.sh \
  && sudo rm -rf /var/cache/yum \
  && cd $HOME \
- && ./install_hysds.sh ${RELEASE} \
+ && ./install_hysds.sh ${FRAMEWORK_BRANCH} ${HYSDS_RELEASE} \
  && rm -rf $HOME/verdi/ops/*/.git* \
  && rm -rf $HOME/.cache \
  && rm -rf $HOME/.git_oauth_token
 
 
-FROM hysds/cuda-base:latest
+FROM hysds/cuda-base:${TAG}
 
 MAINTAINER Gerald Manipon (pymonger) "pymonger@gmail.com"
-LABEL description="HySDS base PGE (product generation executor) image"
+LABEL description="HySDS CUDA base PGE (product generation executor) image"
 
-# git url to hysds dev puppet module
-ENV GIT_URL https://github.com/hysds/puppet-verdi/raw/docker/install.sh
+# get org and branch
+ARG ORG
+ARG BRANCH
+ARG BASE_BRANCH
+
+# git url to hysds verdi puppet module
+ENV GIT_URL https://github.com/${ORG}/puppet-verdi/raw/${BRANCH}/install.sh
 
 # provision via puppet
 RUN set -ex \
  && sudo yum update -y \
  && sudo curl -skL ${GIT_URL} > /tmp/install.sh \
  && sudo chmod 755 /tmp/install.sh \
- && sudo /tmp/install.sh \
+ && sudo /tmp/install.sh ${ORG} ${BRANCH} ${BASE_BRANCH} \
  && sudo rm -rf /etc/puppet/modules/* /mnt/swapfile \
  && sudo yum clean all \
  && sudo rm -f /tmp/install.sh \

--- a/docker/Dockerfile.pge-base
+++ b/docker/Dockerfile.pge-base
@@ -1,14 +1,21 @@
 # syntax = docker/dockerfile:1.0-experimental
-FROM hysds/dev:latest
+ARG TAG=latest
+FROM hysds/dev:${TAG}
 
-# git url to hysds dev puppet module
-ENV GIT_URL https://github.com/hysds/puppet-verdi/raw/docker/install.sh
+# get org and branch
+ARG ORG
+ARG BRANCH
+ARG FRAMEWORK_BRANCH
+ARG BASE_BRANCH
+
+# git url to hysds verdi puppet module
+ENV GIT_URL https://github.com/${ORG}/puppet-verdi/raw/${BRANCH}/install.sh
 
 # get release to install
-ARG RELEASE=develop
+ARG HYSDS_RELEASE=develop
 
 # add latest repo version to invalidate cache
-ADD https://api.github.com/repos/hysds/puppet-verdi/git/refs/heads/docker version.json
+ADD https://api.github.com/repos/${ORG}/puppet-verdi/git/refs/heads/${BRANCH} version.json
 
 # provision via puppet
 RUN --mount=type=secret,id=git_oauth_token sudo cp /run/secrets/git_oauth_token $HOME/.git_oauth_token \
@@ -17,32 +24,37 @@ RUN --mount=type=secret,id=git_oauth_token sudo cp /run/secrets/git_oauth_token 
  && sudo yum update -y \
  && sudo curl -skL ${GIT_URL} > /tmp/install.sh \
  && sudo chmod 755 /tmp/install.sh \
- && sudo /tmp/install.sh \
+ && sudo /tmp/install.sh ${ORG} ${BRANCH} ${BASE_BRANCH} \
  && sudo rm -rf /etc/puppet/modules/* /mnt/swapfile \
  && sudo yum clean all \
  && sudo rm -f /tmp/install.sh \
  && sudo rm -rf /var/cache/yum \
  && cd $HOME \
- && ./install_hysds.sh ${RELEASE} \
+ && ./install_hysds.sh ${FRAMEWORK_BRANCH} ${HYSDS_RELEASE} \
  && rm -rf $HOME/verdi/ops/*/.git* \
  && rm -rf $HOME/.cache \
  && rm -rf $HOME/.git_oauth_token
 
 
-FROM hysds/base:latest
+FROM hysds/base:${TAG}
 
 MAINTAINER Gerald Manipon (pymonger) "pymonger@gmail.com"
 LABEL description="HySDS base PGE (product generation executor) image"
 
-# git url to hysds dev puppet module
-ENV GIT_URL https://github.com/hysds/puppet-verdi/raw/docker/install.sh
+# get org and branch
+ARG ORG
+ARG BRANCH
+ARG BASE_BRANCH
+
+# git url to hysds verdi puppet module
+ENV GIT_URL https://github.com/${ORG}/puppet-verdi/raw/${BRANCH}/install.sh
 
 # provision via puppet
 RUN set -ex \
  && sudo yum update -y \
  && sudo curl -skL ${GIT_URL} > /tmp/install.sh \
  && sudo chmod 755 /tmp/install.sh \
- && sudo /tmp/install.sh \
+ && sudo /tmp/install.sh ${ORG} ${BRANCH} ${BASE_BRANCH} \
  && sudo rm -rf /etc/puppet/modules/* /mnt/swapfile \
  && sudo yum clean all \
  && sudo rm -f /tmp/install.sh \

--- a/install.sh
+++ b/install.sh
@@ -77,7 +77,7 @@ site_pp=$mod_dir/site.pp
 
 # check that module is here; if not, export it
 if [ ! -d $mod_dir ]; then
-  $git_cmd clone --single-branch -b $BASE_BRANCH $git_loc $mod_dir
+  $git_cmd clone --single-branch -b $BASE_BRANCH $git_loc $mod_dir --depth 1
 fi
 
 
@@ -91,7 +91,7 @@ site_pp=$mod_dir/site.pp
 
 # check that module is here; if not, export it
 if [ ! -d $mod_dir ]; then
-  $git_cmd clone --single-branch -b $BRANCH $git_loc $mod_dir
+  $git_cmd clone --single-branch -b $BRANCH $git_loc $mod_dir --depth 1
 fi
 
 

--- a/install.sh
+++ b/install.sh
@@ -11,7 +11,7 @@ ORG=$1
 BRANCH=$2
 BASE_BRANCH=$3
 
-mods_dir=/etc/puppetlabs/code/modules
+mods_dir=/etc/puppet/modules
 mkdir -p $mods_dir
 cd $mods_dir
 

--- a/install.sh
+++ b/install.sh
@@ -1,6 +1,18 @@
 #!/bin/bash
 
-mods_dir=/etc/puppet/modules
+if [ "$#" -ne 3 ]; then
+  echo "Usage: $0 <github org> <branch> <base branch>"
+  echo "e.g.: $0 hysds master master"
+  echo "e.g.: $0 hysds python2 develop"
+  echo "e.g.: $0 pymonger python3 develop"
+  exit 1
+fi
+ORG=$1
+BRANCH=$2
+BASE_BRANCH=$3
+
+mods_dir=/etc/puppetlabs/code/modules
+mkdir -p $mods_dir
 cd $mods_dir
 
 ##########################################
@@ -59,13 +71,13 @@ fi
 # export hysds_base puppet module
 ##########################################
 
-git_loc="${git_url}/hysds/puppet-hysds_base"
+git_loc="${git_url}/${ORG}/puppet-hysds_base"
 mod_dir=$mods_dir/hysds_base
 site_pp=$mod_dir/site.pp
 
 # check that module is here; if not, export it
 if [ ! -d $mod_dir ]; then
-  $git_cmd clone $git_loc $mod_dir
+  $git_cmd clone --single-branch -b $BASE_BRANCH $git_loc $mod_dir
 fi
 
 
@@ -73,13 +85,13 @@ fi
 # export verdi puppet module
 ##########################################
 
-git_loc="${git_url}/hysds/puppet-verdi"
+git_loc="${git_url}/${ORG}/puppet-verdi"
 mod_dir=$mods_dir/verdi
 site_pp=$mod_dir/site.pp
 
 # check that module is here; if not, export it
 if [ ! -d $mod_dir ]; then
-  $git_cmd clone -b docker --single-branch $git_loc $mod_dir
+  $git_cmd clone --single-branch -b $BRANCH $git_loc $mod_dir
 fi
 
 
@@ -87,4 +99,10 @@ fi
 # apply
 ##########################################
 
-$puppet_cmd apply $site_pp
+PUPPET_EXIT_CODE=0
+$puppet_cmd apply --detailed-exitcodes $site_pp || PUPPET_EXIT_CODE=$?
+if [[ ("$PUPPET_EXIT_CODE" -ne 0 ) && ("$PUPPET_EXIT_CODE" -ne 2) ]]; then
+  echo "Puppet failed to run cleanly."
+  exit 1
+fi
+exit 0

--- a/templates/install_hysds.sh
+++ b/templates/install_hysds.sh
@@ -5,16 +5,17 @@ BASE_PATH=$(cd "${BASE_PATH}"; pwd)
 
 # usage
 usage() {
-  echo "usage: $0 <release tag>" >&2
+  echo "usage: $0 <repo branch> <release tag>" >&2
 }
 
 
 # check usage
-if [ $# -ne 1 ]; then
+if [ $# -ne 2 ]; then
   usage
   exit 1
 fi
-release=$1
+branch=$1
+release=$2
 
 
 # print out commands and exit on any errors
@@ -38,7 +39,7 @@ fi
 cd $HOME
 PACKAGE=hysds-framework
 if [ ! -d "$HOME/$PACKAGE" ]; then
-  git clone -b $release --single-branch ${GIT_URL}/hysds/${PACKAGE}.git
+  git clone -b $branch --single-branch ${GIT_URL}/hysds/${PACKAGE}.git
 fi
 cd $HOME/$PACKAGE
 if [ "$release" = "develop" ]; then


### PR DESCRIPTION
Refactored to allow us to build oraclelinux and centos7 docker images automatically. Changes were based off of what was done on the `docker` branch.

```
(base) MT-204713:swot-pcm mcayanan$ docker run -it hysds/verdi:develop-centos7 /bin/bash
ssh-keygen: generating new host keys: RSA1 RSA DSA ECDSA ED25519 
ops@a45852fc1971:~$ more /etc/redhat-release 
CentOS Linux release 7.9.2009 (Core)
ops@a45852fc1971:~$ exit
exit
(base) MT-204713:swot-pcm mcayanan$ docker images | grep verdi
hysds/verdi           20220301          010f9a3181f3   4 hours ago    3.2GB
hysds/verdi           develop-centos7   010f9a3181f3   4 hours ago    3.2GB
```

```
(base) MT-204713:swot-pcm mcayanan$ docker run -it hysds/cuda-pge-base:develop-centos7 /bin/bash
ops@e9745ca57d29:~$ more /etc/redhat-release 
CentOS Linux release 7.9.2009 (Core)

(base) MT-204713:swot-pcm mcayanan$ docker images | grep cuda-pge-base
hysds/cuda-pge-base   20220301          bf5cdd04f054   3 hours ago    3.23GB
hysds/cuda-pge-base   develop-centos7   bf5cdd04f054   3 hours ago    3.23GB

```
