### PR TITLE
HC-522-update: Updates to support moving away from the OPS user in the Core containers

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
 # syntax = docker/dockerfile:1.0-experimental
-ARG TAG=HC-522-update
+ARG TAG=latest
 FROM hysds/pge-base:${TAG}
 
 MAINTAINER Gerald Manipon (pymonger) "pymonger@gmail.com"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -19,8 +19,8 @@ RUN set -ex \
  && ln -sf $HOME/verdi/etc/celeryconfig.py $HOME/verdi/ops/hysds/celeryconfig.py
 
 # set default supervisord conf and copy includes
-COPY --chown=root:root docker/supervisord.conf /home/ops/verdi/etc/supervisord.conf
-COPY --chown=root:root docker/conf.d /home/ops/verdi/etc/conf.d
+COPY --chown=root:root docker/supervisord.conf $HOME/verdi/etc/supervisord.conf
+COPY --chown=root:root docker/conf.d $HOME/verdi/etc/conf.d
 
 # set entrypoint
 COPY docker/entrypoint* /

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -16,7 +16,7 @@ RUN set -ex \
  && cd hysds \
  && git checkout -b HC-522-update origin/HC-522-update \
  && pip install -e . \
- && ln -sf /home/ops/verdi/etc/celeryconfig.py /home/ops/verdi/ops/hysds/celeryconfig.py \
+ && ln -sf /home/ops/verdi/etc/celeryconfig.py /home/ops/verdi/ops/hysds/celeryconfig.py
 
 # set default supervisord conf and copy includes
 COPY --chown=ops:ops docker/supervisord.conf /home/ops/verdi/etc/supervisord.conf

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,8 +7,8 @@ LABEL description="HySDS verdi image"
 
 # link configs
 RUN set -ex \
- && ln -sf /home/ops/verdi/etc/celeryconfig.py /home/ops/verdi/ops/hysds/celeryconfig.py \
- && source /home/ops/.bash_profile \
+ && ln -sf $HOME/verdi/etc/celeryconfig.py $HOME/verdi/ops/hysds/celeryconfig.py \
+ && source $HOME/.bash_profile \
  && mv $HOME/verdi/ops/sciflo $HOME/verdi/ops/sciflo.bak \
  && mv $HOME/verdi/ops/hysds $HOME/verdi/ops/hysds.bak \
  && cd $HOME/verdi/ops \
@@ -16,11 +16,11 @@ RUN set -ex \
  && cd hysds \
  && git checkout -b HC-522-update origin/HC-522-update \
  && pip install -e . \
- && ln -sf /home/ops/verdi/etc/celeryconfig.py /home/ops/verdi/ops/hysds/celeryconfig.py
+ && ln -sf $HOME/verdi/etc/celeryconfig.py $HOME/verdi/ops/hysds/celeryconfig.py
 
 # set default supervisord conf and copy includes
-COPY --chown=ops:ops docker/supervisord.conf /home/ops/verdi/etc/supervisord.conf
-COPY --chown=ops:ops docker/conf.d /home/ops/verdi/etc/conf.d
+COPY --chown=root:root docker/supervisord.conf /home/ops/verdi/etc/supervisord.conf
+COPY --chown=root:root docker/conf.d /home/ops/verdi/etc/conf.d
 
 # set entrypoint
 COPY docker/entrypoint* /

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,13 +1,22 @@
 # syntax = docker/dockerfile:1.0-experimental
 ARG TAG=latest
-FROM hysds/pge-base:${TAG}
+FROM hysds/pge-base:HC-522-update
 
 MAINTAINER Gerald Manipon (pymonger) "pymonger@gmail.com"
 LABEL description="HySDS verdi image"
 
 # link configs
 RUN set -ex \
- && ln -sf /home/ops/verdi/etc/celeryconfig.py /home/ops/verdi/ops/hysds/celeryconfig.py
+ && ln -sf /home/ops/verdi/etc/celeryconfig.py /home/ops/verdi/ops/hysds/celeryconfig.py \
+ && source /home/ops/.bash_profile \
+ && mv $HOME/verdi/ops/sciflo $HOME/verdi/ops/sciflo.bak \
+ && mv $HOME/verdi/ops/hysds $HOME/verdi/ops/hysds.bak \
+ && cd $HOME/verdi/ops \
+ && git clone https://github.com/hysds/hysds.git \
+ && cd hysds \
+ && git checkout -b HC-522-update origin/HC-522-update \
+ && pip install -e . \
+ && ln -sf /home/ops/verdi/etc/celeryconfig.py /home/ops/verdi/ops/hysds/celeryconfig.py \
 
 # set default supervisord conf and copy includes
 COPY --chown=ops:ops docker/supervisord.conf /home/ops/verdi/etc/supervisord.conf

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,6 @@
 # syntax = docker/dockerfile:1.0-experimental
-ARG TAG=latest
-FROM hysds/pge-base:HC-522-update
+ARG TAG=HC-522-update
+FROM hysds/pge-base:${TAG}
 
 MAINTAINER Gerald Manipon (pymonger) "pymonger@gmail.com"
 LABEL description="HySDS verdi image"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -9,7 +9,6 @@ LABEL description="HySDS verdi image"
 RUN set -ex \
  && ln -sf $HOME/verdi/etc/celeryconfig.py $HOME/verdi/ops/hysds/celeryconfig.py \
  && source $HOME/.bash_profile \
- && mv $HOME/verdi/ops/sciflo $HOME/verdi/ops/sciflo.bak \
  && mv $HOME/verdi/ops/hysds $HOME/verdi/ops/hysds.bak \
  && cd $HOME/verdi/ops \
  && git clone https://github.com/hysds/hysds.git \

--- a/docker/Dockerfile.cuda-pge-base
+++ b/docker/Dockerfile.cuda-pge-base
@@ -1,5 +1,5 @@
 # syntax = docker/dockerfile:1.0-experimental
-ARG TAG=HC-522-update
+ARG TAG=latest
 FROM hysds/cuda-dev:${TAG}
 
 # get org and branch

--- a/docker/Dockerfile.cuda-pge-base
+++ b/docker/Dockerfile.cuda-pge-base
@@ -29,6 +29,7 @@ RUN --mount=type=secret,id=git_oauth_token sudo cp /run/secrets/git_oauth_token 
  && sudo dnf clean all \
  && sudo rm -f /tmp/install.sh \
  && sudo rm -rf /var/cache/dnf \
+ && source $HOME/.bash_profile \
  && cd $HOME \
  && ./install_hysds.sh ${FRAMEWORK_BRANCH} ${HYSDS_RELEASE} \
  && rm -rf $HOME/verdi/ops/*/.git* \

--- a/docker/Dockerfile.cuda-pge-base
+++ b/docker/Dockerfile.cuda-pge-base
@@ -63,6 +63,17 @@ RUN set -ex \
 # copy ops home
 COPY --chown=ops:ops --from=0 /home/ops /home/ops
 
+# These are podman-specific things to set up the "root" in the container
+# (root is the host user from podman perspective)
+USER root
+ENV USER root
+ENV GROUP root
+
+RUN rm -rf /root && ln -s /home/ops /root
+WORKDIR /root/
+VOLUME /root/.local/share/containers
+RUN chown -R root:root /home/ops && chown -R root:root /root
+
 # set entrypoint
 COPY docker/entrypoint* /
 ENTRYPOINT ["/entrypoint-pge.sh"]

--- a/docker/Dockerfile.cuda-pge-base
+++ b/docker/Dockerfile.cuda-pge-base
@@ -60,19 +60,8 @@ RUN set -ex \
  && sudo rm -f /tmp/install.sh \
  && sudo rm -rf /var/cache/dnf
 
-# copy ops home
+# copy root
 COPY --chown=root:root --from=0 /root /root
-
-# These are podman-specific things to set up the "root" in the container
-# (root is the host user from podman perspective)
-#USER root
-#ENV USER root
-#ENV GROUP root
-
-#RUN rm -rf /root && ln -s /home/ops /root
-#WORKDIR /root/
-#VOLUME /root/.local/share/containers
-#RUN chown -R root:root /home/ops && chown -R root:root /root
 
 # set entrypoint
 COPY docker/entrypoint* /

--- a/docker/Dockerfile.cuda-pge-base
+++ b/docker/Dockerfile.cuda-pge-base
@@ -19,7 +19,7 @@ ADD https://api.github.com/repos/${ORG}/puppet-verdi/git/refs/heads/${BRANCH} ve
 
 # provision via puppet
 RUN --mount=type=secret,id=git_oauth_token sudo cp /run/secrets/git_oauth_token $HOME/.git_oauth_token \
- && sudo chown ops:ops $HOME/.git_oauth_token \
+ && sudo chown root:root $HOME/.git_oauth_token \
  && set -ex \
  && sudo dnf update -y \
  && sudo curl -skL ${GIT_URL} > /tmp/install.sh \

--- a/docker/Dockerfile.cuda-pge-base
+++ b/docker/Dockerfile.cuda-pge-base
@@ -61,18 +61,18 @@ RUN set -ex \
  && sudo rm -rf /var/cache/dnf
 
 # copy ops home
-COPY --chown=ops:ops --from=0 /home/ops /home/ops
+COPY --chown=root:root --from=0 /root /root
 
 # These are podman-specific things to set up the "root" in the container
 # (root is the host user from podman perspective)
-USER root
-ENV USER root
-ENV GROUP root
+#USER root
+#ENV USER root
+#ENV GROUP root
 
-RUN rm -rf /root && ln -s /home/ops /root
-WORKDIR /root/
-VOLUME /root/.local/share/containers
-RUN chown -R root:root /home/ops && chown -R root:root /root
+#RUN rm -rf /root && ln -s /home/ops /root
+#WORKDIR /root/
+#VOLUME /root/.local/share/containers
+#RUN chown -R root:root /home/ops && chown -R root:root /root
 
 # set entrypoint
 COPY docker/entrypoint* /

--- a/docker/Dockerfile.cuda-pge-base
+++ b/docker/Dockerfile.cuda-pge-base
@@ -29,7 +29,6 @@ RUN --mount=type=secret,id=git_oauth_token sudo cp /run/secrets/git_oauth_token 
  && sudo dnf clean all \
  && sudo rm -f /tmp/install.sh \
  && sudo rm -rf /var/cache/dnf \
- && source $HOME/.bash_profile \
  && cd $HOME \
  && ./install_hysds.sh ${FRAMEWORK_BRANCH} ${HYSDS_RELEASE} \
  && rm -rf $HOME/verdi/ops/*/.git* \

--- a/docker/Dockerfile.cuda-pge-base
+++ b/docker/Dockerfile.cuda-pge-base
@@ -1,6 +1,6 @@
 # syntax = docker/dockerfile:1.0-experimental
 ARG TAG=latest
-FROM hysds/cuda-dev:${TAG}
+FROM hysds/cuda-dev:HC-522-update
 
 # get org and branch
 ARG ORG

--- a/docker/Dockerfile.cuda-pge-base
+++ b/docker/Dockerfile.cuda-pge-base
@@ -1,6 +1,6 @@
 # syntax = docker/dockerfile:1.0-experimental
-ARG TAG=latest
-FROM hysds/cuda-dev:HC-522-update
+ARG TAG=HC-522-update
+FROM hysds/cuda-dev:${TAG}
 
 # get org and branch
 ARG ORG

--- a/docker/Dockerfile.pge-base
+++ b/docker/Dockerfile.pge-base
@@ -1,5 +1,5 @@
 # syntax = docker/dockerfile:1.0-experimental
-ARG TAG=HC-522-update
+ARG TAG=latest
 FROM hysds/dev:${TAG}
 
 # get org and branch

--- a/docker/Dockerfile.pge-base
+++ b/docker/Dockerfile.pge-base
@@ -63,6 +63,9 @@ RUN set -ex \
 # copy ops home
 COPY --chown=root:root --from=0 /root /root
 
+# softlink to ops home
+RUN ln -s /root /home/ops
+
 # These are podman-specific things to set up the "root" in the container
 # (root is the host user from podman perspective)
 #USER root

--- a/docker/Dockerfile.pge-base
+++ b/docker/Dockerfile.pge-base
@@ -65,14 +65,14 @@ COPY --chown=ops:ops --from=0 /home/ops /home/ops
 
 # These are podman-specific things to set up the "root" in the container
 # (root is the host user from podman perspective)
-USER root
-ENV USER root
-ENV GROUP root
+#USER root
+#ENV USER root
+#ENV GROUP root
 
-RUN rm -rf /root && ln -s /home/ops /root
-WORKDIR /root/
-VOLUME /root/.local/share/containers
-RUN chown -R root:root /home/ops && chown -R root:root /root
+#RUN rm -rf /root && ln -s /home/ops /root
+#WORKDIR /root/
+#VOLUME /root/.local/share/containers
+#RUN chown -R root:root /home/ops && chown -R root:root /root
 
 # set entrypoint
 COPY docker/entrypoint* /

--- a/docker/Dockerfile.pge-base
+++ b/docker/Dockerfile.pge-base
@@ -1,6 +1,6 @@
 # syntax = docker/dockerfile:1.0-experimental
-ARG TAG=latest
-FROM hysds/dev:HC-522-update
+ARG TAG=HC-522-update
+FROM hysds/dev:${TAG}
 
 # get org and branch
 ARG ORG

--- a/docker/Dockerfile.pge-base
+++ b/docker/Dockerfile.pge-base
@@ -29,6 +29,7 @@ RUN --mount=type=secret,id=git_oauth_token sudo cp /run/secrets/git_oauth_token 
  && sudo dnf clean all \
  && sudo rm -f /tmp/install.sh \
  && sudo rm -rf /var/cache/dnf \
+ && source $HOME/.bash_profile \
  && cd $HOME \
  && ./install_hysds.sh ${FRAMEWORK_BRANCH} ${HYSDS_RELEASE} \
  && rm -rf $HOME/verdi/ops/*/.git* \

--- a/docker/Dockerfile.pge-base
+++ b/docker/Dockerfile.pge-base
@@ -63,6 +63,17 @@ RUN set -ex \
 # copy ops home
 COPY --chown=ops:ops --from=0 /home/ops /home/ops
 
+# These are podman-specific things to set up the "root" in the container
+# (root is the host user from podman perspective)
+USER root
+ENV USER root
+ENV GROUP root
+
+RUN rm -rf /root && ln -s /home/ops /root
+WORKDIR /root/
+VOLUME /root/.local/share/containers
+RUN chown -R root:root /home/ops && chown -R root:root /root
+
 # set entrypoint
 COPY docker/entrypoint* /
 ENTRYPOINT ["/entrypoint-pge.sh"]

--- a/docker/Dockerfile.pge-base
+++ b/docker/Dockerfile.pge-base
@@ -60,11 +60,8 @@ RUN set -ex \
  && sudo rm -f /tmp/install.sh \
  && sudo rm -rf /var/cache/dnf
 
-# copy ops home
+# copy root
 COPY --chown=root:root --from=0 /root /root
-
-# softlink /root to /home/ops to maintain backwards compatability
-RUN rm -rf /home/ops && ln -s /root /home/ops
 
 # set entrypoint
 COPY docker/entrypoint* /

--- a/docker/Dockerfile.pge-base
+++ b/docker/Dockerfile.pge-base
@@ -64,7 +64,7 @@ RUN set -ex \
 COPY --chown=root:root --from=0 /root /root
 
 # softlink to ops home
-RUN ln -s /root/* /home/ops/
+RUN rm -rf /home/ops && ln -s /root /home/ops
 
 # These are podman-specific things to set up the "root" in the container
 # (root is the host user from podman perspective)

--- a/docker/Dockerfile.pge-base
+++ b/docker/Dockerfile.pge-base
@@ -19,7 +19,7 @@ ADD https://api.github.com/repos/${ORG}/puppet-verdi/git/refs/heads/${BRANCH} ve
 
 # provision via puppet
 RUN --mount=type=secret,id=git_oauth_token sudo cp /run/secrets/git_oauth_token $HOME/.git_oauth_token \
- && sudo chown ops:ops $HOME/.git_oauth_token \
+ && sudo chown root:root $HOME/.git_oauth_token \
  && set -ex \
  && sudo dnf update -y \
  && sudo curl -skL ${GIT_URL} > /tmp/install.sh \

--- a/docker/Dockerfile.pge-base
+++ b/docker/Dockerfile.pge-base
@@ -63,16 +63,8 @@ RUN set -ex \
 # copy ops home
 COPY --chown=root:root --from=0 /root /root
 
-# These are podman-specific things to set up the "root" in the container
-# (root is the host user from podman perspective)
-#USER root
-#ENV USER root
-#ENV GROUP root
-
-#RUN rm -rf /root && ln -s /home/ops /root
-#WORKDIR /root/
-#VOLUME /root/.local/share/containers
-#RUN chown -R root:root /home/ops && chown -R root:root /root
+# softlink /root to /home/ops to maintain backwards compatability
+RUN rm -rf /home/ops && ln -s /root /home/ops
 
 # set entrypoint
 COPY docker/entrypoint* /

--- a/docker/Dockerfile.pge-base
+++ b/docker/Dockerfile.pge-base
@@ -63,9 +63,6 @@ RUN set -ex \
 # copy ops home
 COPY --chown=root:root --from=0 /root /root
 
-# softlink to ops home
-RUN rm -rf /home/ops && ln -s /root /home/ops
-
 # These are podman-specific things to set up the "root" in the container
 # (root is the host user from podman perspective)
 #USER root

--- a/docker/Dockerfile.pge-base
+++ b/docker/Dockerfile.pge-base
@@ -29,7 +29,6 @@ RUN --mount=type=secret,id=git_oauth_token sudo cp /run/secrets/git_oauth_token 
  && sudo dnf clean all \
  && sudo rm -f /tmp/install.sh \
  && sudo rm -rf /var/cache/dnf \
- && source $HOME/.bash_profile \
  && cd $HOME \
  && ./install_hysds.sh ${FRAMEWORK_BRANCH} ${HYSDS_RELEASE} \
  && rm -rf $HOME/verdi/ops/*/.git* \

--- a/docker/Dockerfile.pge-base
+++ b/docker/Dockerfile.pge-base
@@ -1,6 +1,6 @@
 # syntax = docker/dockerfile:1.0-experimental
 ARG TAG=latest
-FROM hysds/dev:${TAG}
+FROM hysds/dev:HC-522-update
 
 # get org and branch
 ARG ORG

--- a/docker/Dockerfile.pge-base
+++ b/docker/Dockerfile.pge-base
@@ -61,7 +61,7 @@ RUN set -ex \
  && sudo rm -rf /var/cache/dnf
 
 # copy ops home
-COPY --chown=ops:ops --from=0 /home/ops /home/ops
+COPY --chown=root:root --from=0 /root /root
 
 # These are podman-specific things to set up the "root" in the container
 # (root is the host user from podman perspective)

--- a/docker/Dockerfile.pge-base
+++ b/docker/Dockerfile.pge-base
@@ -64,7 +64,7 @@ RUN set -ex \
 COPY --chown=root:root --from=0 /root /root
 
 # softlink to ops home
-RUN ln -s /root /home/ops
+RUN ln -s /root/* /home/ops/
 
 # These are podman-specific things to set up the "root" in the container
 # (root is the host user from podman perspective)

--- a/docker/entrypoint-common.sh
+++ b/docker/entrypoint-common.sh
@@ -51,7 +51,7 @@ GID=$(id -g)
 #gosu 0:0 usermod -d ${HOME} ops 2>/dev/null
 
 # update ownership of other files
-#if [ -e /var/run/docker.sock ]; then
+if [ -e /var/run/docker.sock ]; then
   # update ownership of home dir and hidden files/dirs
 #  gosu 0:0 chown $UID:$GID $HOME 2>/dev/null || true
 #  gosu 0:0 chown -R $UID:$GID $HOME/.[!.]* 2>/dev/null || true
@@ -62,7 +62,7 @@ GID=$(id -g)
 #  gosu 0:0 chown -R $UID:$GID $HOME/verdi/etc 2>/dev/null || true
 #  gosu 0:0 chown -R $UID:$GID $HOME/verdi/log 2>/dev/null || true
 #  gosu 0:0 chown -R $UID:$GID $HOME/verdi/run 2>/dev/null || true
-#  gosu 0:0 chown -R $UID:$GID /var/run/docker.sock 2>/dev/null || true
+  gosu 0:0 chown -R $UID:$GID /var/run/docker.sock 2>/dev/null || true
 #else
   # Assume podman
   # We need to give sudo priviliges to start up httpd to the host user
@@ -71,4 +71,4 @@ GID=$(id -g)
 #    gosu 0:0 su root -c "echo '${HOST_USER} ALL=NOPASSWD: /usr/sbin/apachectl' >> /etc/sudoers.d/90-cloudimg-ops"
 #    gosu 0:0 su root -c "chmod u-w /etc/sudoers.d/90-cloudimg-ops"
 #  fi
-#fi
+fi

--- a/docker/entrypoint-common.sh
+++ b/docker/entrypoint-common.sh
@@ -20,19 +20,18 @@ fi
 # restore home dir
 gosu 0:0 usermod -d ${HOME} ops 2>/dev/null
 
-# update ownership of home dir and hidden files/dirs
-gosu 0:0 chown $UID:$GID $HOME 2>/dev/null || true
-gosu 0:0 chown -R $UID:$GID $HOME/.[!.]* 2>/dev/null || true
-
-# update ownership of verdi files/dirs
-gosu 0:0 chown $UID:$GID $HOME/verdi 2>/dev/null || true
-gosu 0:0 chown $UID:$GID $HOME/verdi/ops 2>/dev/null || true
-gosu 0:0 chown -R $UID:$GID $HOME/verdi/etc 2>/dev/null || true
-gosu 0:0 chown -R $UID:$GID $HOME/verdi/log 2>/dev/null || true
-gosu 0:0 chown -R $UID:$GID $HOME/verdi/run 2>/dev/null || true
-
 # update ownership of other files
 if [ -e /var/run/docker.sock ]; then
+  # update ownership of home dir and hidden files/dirs
+  gosu 0:0 chown $UID:$GID $HOME 2>/dev/null || true
+  gosu 0:0 chown -R $UID:$GID $HOME/.[!.]* 2>/dev/null || true
+
+  # update ownership of verdi files/dirs
+  gosu 0:0 chown $UID:$GID $HOME/verdi 2>/dev/null || true
+  gosu 0:0 chown $UID:$GID $HOME/verdi/ops 2>/dev/null || true
+  gosu 0:0 chown -R $UID:$GID $HOME/verdi/etc 2>/dev/null || true
+  gosu 0:0 chown -R $UID:$GID $HOME/verdi/log 2>/dev/null || true
+  gosu 0:0 chown -R $UID:$GID $HOME/verdi/run 2>/dev/null || true
   gosu 0:0 chown -R $UID:$GID /var/run/docker.sock 2>/dev/null || true
 else
   # Assume podman

--- a/docker/entrypoint-common.sh
+++ b/docker/entrypoint-common.sh
@@ -1,48 +1,44 @@
 #!/bin/bash
 
 # set HOME explicitly
-if [ -e /var/run/docker.sock ]; then
-  export HOME=/home/ops
-else
-  export HOME=/root
-fi
+export HOME=/root
 
 # get group id
 GID=$(id -g)
 
 # temporarily change home dir to bypass usermod's recursive chown of home dir
-gosu 0:0 usermod -d /tmp/${HOME} ops 2>/dev/null
+#gosu 0:0 usermod -d /tmp/${HOME} ops 2>/dev/null
 
 # update user and group ids
-if [ -e /var/run/docker.sock ]; then
+#if [ -e /var/run/docker.sock ]; then
   # These groupmod/usermod commands are needed in order to start up httpd under sudo
-  gosu 0:0 groupmod -g $GID ops 2>/dev/null
-  gosu 0:0 usermod -u $UID -g $GID ops 2>/dev/null
-  gosu 0:0 usermod -aG docker ops 2>/dev/null
-fi
+#  gosu 0:0 groupmod -g $GID ops 2>/dev/null
+#  gosu 0:0 usermod -u $UID -g $GID ops 2>/dev/null
+#  gosu 0:0 usermod -aG docker ops 2>/dev/null
+#fi
 
 # restore home dir
-gosu 0:0 usermod -d ${HOME} ops 2>/dev/null
+#gosu 0:0 usermod -d ${HOME} ops 2>/dev/null
 
 # update ownership of other files
-if [ -e /var/run/docker.sock ]; then
+#if [ -e /var/run/docker.sock ]; then
   # update ownership of home dir and hidden files/dirs
-  gosu 0:0 chown $UID:$GID $HOME 2>/dev/null || true
-  gosu 0:0 chown -R $UID:$GID $HOME/.[!.]* 2>/dev/null || true
+#  gosu 0:0 chown $UID:$GID $HOME 2>/dev/null || true
+#  gosu 0:0 chown -R $UID:$GID $HOME/.[!.]* 2>/dev/null || true
 
   # update ownership of verdi files/dirs
-  gosu 0:0 chown $UID:$GID $HOME/verdi 2>/dev/null || true
-  gosu 0:0 chown $UID:$GID $HOME/verdi/ops 2>/dev/null || true
-  gosu 0:0 chown -R $UID:$GID $HOME/verdi/etc 2>/dev/null || true
-  gosu 0:0 chown -R $UID:$GID $HOME/verdi/log 2>/dev/null || true
-  gosu 0:0 chown -R $UID:$GID $HOME/verdi/run 2>/dev/null || true
-  gosu 0:0 chown -R $UID:$GID /var/run/docker.sock 2>/dev/null || true
-else
+#  gosu 0:0 chown $UID:$GID $HOME/verdi 2>/dev/null || true
+#  gosu 0:0 chown $UID:$GID $HOME/verdi/ops 2>/dev/null || true
+#  gosu 0:0 chown -R $UID:$GID $HOME/verdi/etc 2>/dev/null || true
+#  gosu 0:0 chown -R $UID:$GID $HOME/verdi/log 2>/dev/null || true
+#  gosu 0:0 chown -R $UID:$GID $HOME/verdi/run 2>/dev/null || true
+#  gosu 0:0 chown -R $UID:$GID /var/run/docker.sock 2>/dev/null || true
+#else
   # Assume podman
   # We need to give sudo priviliges to start up httpd to the host user
-  if [[ ! -z "$HOST_USER" ]]; then
-    gosu 0:0 su root -c "chmod u+w /etc/sudoers.d/90-cloudimg-ops"
-    gosu 0:0 su root -c "echo '${HOST_USER} ALL=NOPASSWD: /usr/sbin/apachectl' >> /etc/sudoers.d/90-cloudimg-ops"
-    gosu 0:0 su root -c "chmod u-w /etc/sudoers.d/90-cloudimg-ops"
-  fi
-fi
+#  if [[ ! -z "$HOST_USER" ]]; then
+#    gosu 0:0 su root -c "chmod u+w /etc/sudoers.d/90-cloudimg-ops"
+#    gosu 0:0 su root -c "echo '${HOST_USER} ALL=NOPASSWD: /usr/sbin/apachectl' >> /etc/sudoers.d/90-cloudimg-ops"
+#    gosu 0:0 su root -c "chmod u-w /etc/sudoers.d/90-cloudimg-ops"
+#  fi
+#fi

--- a/docker/entrypoint-common.sh
+++ b/docker/entrypoint-common.sh
@@ -6,69 +6,7 @@ export HOME=/root
 # get group id
 GID=$(id -g)
 
-
-###################
-# ADD THIS CODE IF WE WANT TO CONTINUE TO ALLOW HTTPD TO BE START UP WITHIN THE CONTAINER
-###################
-
-# Set the user
-#USER=$(whoami)
-#if [[ ! -z "$HOST_USER" ]]; then
-#  USER=${HOST_USER}
-#fi
-
-# Create a group from the host group id if it does not exist
-#if ! getent group $GID > /dev/null 2>&1; then
-#  gosu 0:0 su root -c "groupadd -g $GID host_group"
-#fi
-
-# Create the user if it does not exist
-#if ! id -u $USER > /dev/null 2>&1; then
-#  gosu 0:0 su root -c "useradd -u $UID -g $GID -Ms /bin/bash $USER"
-#fi
-
-#USER=${USER}
-#if [[ ! -z "$HOST_USER" ]]; then
-#  USER=${HOST_USER}
-#fi
-
-# Give sudo permissions to start up httpd
-#gosu 0:0 su root -c "echo '${USER} ALL=NOPASSWD: /usr/sbin/apachectl' > /etc/sudoers.d/90-cloudimg-user"
-#gosu 0:0 su root -c "chmod u-w /etc/sudoers.d/90-cloudimg-user"
-
-# temporarily change home dir to bypass usermod's recursive chown of home dir
-#gosu 0:0 usermod -d /tmp/${HOME} ops 2>/dev/null
-
-# update user and group ids
-#if [ -e /var/run/docker.sock ]; then
-  # These groupmod/usermod commands are needed in order to start up httpd under sudo
-#  gosu 0:0 groupmod -g $GID ops 2>/dev/null
-#  gosu 0:0 usermod -u $UID -g $GID ops 2>/dev/null
-#  gosu 0:0 usermod -aG docker ops 2>/dev/null
-#fi
-
-# restore home dir
-#gosu 0:0 usermod -d ${HOME} ops 2>/dev/null
-
 # update ownership of other files
 if [ -e /var/run/docker.sock ]; then
-  # update ownership of home dir and hidden files/dirs
-#  gosu 0:0 chown $UID:$GID $HOME 2>/dev/null || true
-#  gosu 0:0 chown -R $UID:$GID $HOME/.[!.]* 2>/dev/null || true
-
-  # update ownership of verdi files/dirs
-#  gosu 0:0 chown $UID:$GID $HOME/verdi 2>/dev/null || true
-#  gosu 0:0 chown $UID:$GID $HOME/verdi/ops 2>/dev/null || true
-#  gosu 0:0 chown -R $UID:$GID $HOME/verdi/etc 2>/dev/null || true
-#  gosu 0:0 chown -R $UID:$GID $HOME/verdi/log 2>/dev/null || true
-#  gosu 0:0 chown -R $UID:$GID $HOME/verdi/run 2>/dev/null || true
   gosu 0:0 chown -R $UID:$GID /var/run/docker.sock 2>/dev/null || true
-#else
-  # Assume podman
-  # We need to give sudo priviliges to start up httpd to the host user
-#  if [[ ! -z "$HOST_USER" ]]; then
-#    gosu 0:0 su root -c "chmod u+w /etc/sudoers.d/90-cloudimg-ops"
-#    gosu 0:0 su root -c "echo '${HOST_USER} ALL=NOPASSWD: /usr/sbin/apachectl' >> /etc/sudoers.d/90-cloudimg-ops"
-#    gosu 0:0 su root -c "chmod u-w /etc/sudoers.d/90-cloudimg-ops"
-#  fi
 fi

--- a/docker/entrypoint-common.sh
+++ b/docker/entrypoint-common.sh
@@ -6,6 +6,36 @@ export HOME=/root
 # get group id
 GID=$(id -g)
 
+
+###################
+# ADD THIS CODE IF WE WANT TO CONTINUE TO ALLOW HTTPD TO BE START UP WITHIN THE CONTAINER
+###################
+
+# Set the user
+#USER=$(whoami)
+#if [[ ! -z "$HOST_USER" ]]; then
+#  USER=${HOST_USER}
+#fi
+
+# Create a group from the host group id if it does not exist
+#if ! getent group $GID > /dev/null 2>&1; then
+#  gosu 0:0 su root -c "groupadd -g $GID host_group"
+#fi
+
+# Create the user if it does not exist
+#if ! id -u $USER > /dev/null 2>&1; then
+#  gosu 0:0 su root -c "useradd -u $UID -g $GID -Ms /bin/bash $USER"
+#fi
+
+#USER=${USER}
+#if [[ ! -z "$HOST_USER" ]]; then
+#  USER=${HOST_USER}
+#fi
+
+# Give sudo permissions to start up httpd
+#gosu 0:0 su root -c "echo '${USER} ALL=NOPASSWD: /usr/sbin/apachectl' > /etc/sudoers.d/90-cloudimg-user"
+#gosu 0:0 su root -c "chmod u-w /etc/sudoers.d/90-cloudimg-user"
+
 # temporarily change home dir to bypass usermod's recursive chown of home dir
 #gosu 0:0 usermod -d /tmp/${HOME} ops 2>/dev/null
 

--- a/docker/entrypoint-common.sh
+++ b/docker/entrypoint-common.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # set HOME explicitly
-export HOME=/home/ops
+export HOME=/root
 
 # get group id
 GID=$(id -g)

--- a/docker/entrypoint-common.sh
+++ b/docker/entrypoint-common.sh
@@ -1,7 +1,11 @@
 #!/bin/bash
 
 # set HOME explicitly
-export HOME=/root
+if [ -e /var/run/docker.sock ]; then
+  export HOME=/home/ops
+else
+  export HOME=/root
+fi
 
 # get group id
 GID=$(id -g)

--- a/docker/entrypoint-verdi-common.sh
+++ b/docker/entrypoint-verdi-common.sh
@@ -13,7 +13,7 @@ gosu 0:0 ssh-keygen -A 2>/dev/null
 if [ ! -d "/data/work/.index-style" ]; then
   gosu 0:0 mkdir -p /data/work
   gosu 0:0 tar -C /data/work -xjf $HOME/verdi/src/beefed-autoindex-open_in_new_win.tbz2
-  gosu 0:0 chmod -R 0755 /data/work 2>/dev/null || true
+  gosu 0:0 chown -R $UID:$GID /data/work 2>/dev/null || true
 fi
 
 # source bash profile

--- a/docker/entrypoint-verdi-common.sh
+++ b/docker/entrypoint-verdi-common.sh
@@ -7,13 +7,13 @@ gosu 0:0 ssh-keygen -A 2>/dev/null
 . /entrypoint-common.sh
 
 # update ownership of other files
-gosu 0:0 chown -R $UID:$GID /var/log/supervisor 2>/dev/null || true
+#gosu 0:0 chown -R $UID:$GID /var/log/supervisor 2>/dev/null || true
 
 # unpack work dir style
 if [ ! -d "/data/work/.index-style" ]; then
   gosu 0:0 mkdir -p /data/work
   gosu 0:0 tar -C /data/work -xjf $HOME/verdi/src/beefed-autoindex-open_in_new_win.tbz2
-  gosu 0:0 chown -R $UID:$GID /data/work 2>/dev/null || true
+  gosu 0:0 chmod -R 0755 /data/work 2>/dev/null || true
 fi
 
 # source bash profile

--- a/docker/entrypoint-verdi-common.sh
+++ b/docker/entrypoint-verdi-common.sh
@@ -6,16 +6,6 @@ gosu 0:0 ssh-keygen -A 2>/dev/null
 # common entrypoint tasks
 . /entrypoint-common.sh
 
-# update ownership of other files
-#gosu 0:0 chown -R $UID:$GID /var/log/supervisor 2>/dev/null || true
-
-# unpack work dir style
-#if [ ! -d "/data/work/.index-style" ]; then
-#  gosu 0:0 mkdir -p /data/work
-#  gosu 0:0 tar -C /data/work -xjf $HOME/verdi/src/beefed-autoindex-open_in_new_win.tbz2
-#  gosu 0:0 chown -R $UID:$GID /data/work 2>/dev/null || true
-#fi
-
 # source bash profile
 source $HOME/.bash_profile
 

--- a/docker/entrypoint-verdi-common.sh
+++ b/docker/entrypoint-verdi-common.sh
@@ -10,11 +10,11 @@ gosu 0:0 ssh-keygen -A 2>/dev/null
 #gosu 0:0 chown -R $UID:$GID /var/log/supervisor 2>/dev/null || true
 
 # unpack work dir style
-if [ ! -d "/data/work/.index-style" ]; then
-  gosu 0:0 mkdir -p /data/work
-  gosu 0:0 tar -C /data/work -xjf $HOME/verdi/src/beefed-autoindex-open_in_new_win.tbz2
-  gosu 0:0 chown -R $UID:$GID /data/work 2>/dev/null || true
-fi
+#if [ ! -d "/data/work/.index-style" ]; then
+#  gosu 0:0 mkdir -p /data/work
+#  gosu 0:0 tar -C /data/work -xjf $HOME/verdi/src/beefed-autoindex-open_in_new_win.tbz2
+#  gosu 0:0 chown -R $UID:$GID /data/work 2>/dev/null || true
+#fi
 
 # source bash profile
 source $HOME/.bash_profile

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -8,13 +8,22 @@ class verdi inherits hysds_base {
   # copy user files
   #####################################################
 
-  file { "/$user/.bash_profile":
+  file { "/$root_user/.bash_profile":
     ensure  => present,
     content => template('verdi/bash_profile'),
-    owner   => $user,
-    group   => $group,
+    owner   => $root_user,
+    group   => $root_group,
     mode    => "0644",
-    require => User[$user],
+    require => User[$root_user],
+  }
+
+  file { "/$ops_user/.bash_profile":
+    ensure  => present,
+    content => template('verdi/bash_profile'),
+    owner   => $ops_user,
+    group   => $ops_group,
+    mode    => "0644",
+    require => User[$ops_user],
   }
 
 
@@ -29,8 +38,7 @@ class verdi inherits hysds_base {
   # verdi directory
   #####################################################
 
-  $verdi_dir = "/$user/verdi"
-
+  $verdi_dir = "/$root_user/verdi"
 
   #####################################################
   # install packages

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -17,7 +17,7 @@ class verdi inherits hysds_base {
     require => User[$root_user],
   }
 
-  file { "/$ops_user/.bash_profile":
+  file { "/home/$ops_user/.bash_profile":
     ensure  => present,
     content => template('verdi/bash_profile'),
     owner   => $ops_user,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -69,8 +69,8 @@ class verdi inherits hysds_base {
 
   file { "$verdi_dir/src/beefed-autoindex-open_in_new_win.tbz2":
     ensure  => file,
-    owner   => $user,
-    group   => $group,
+    owner   => $root_user,
+    group   => $root_group,
     mode    => "0644",
     source => 'puppet:///modules/verdi/beefed-autoindex-open_in_new_win.tbz2',
     require => [
@@ -84,13 +84,13 @@ class verdi inherits hysds_base {
   # files in ops home
   #####################################################
 
-  file { "/$user/install_hysds.sh":
+  file { "/$root_user/install_hysds.sh":
     ensure  => present,
     content => template('verdi/install_hysds.sh'),
-    owner   => $user,
-    group   => $group,
+    owner   => $root_user,
+    group   => $root_group,
     mode    => "0755",
-    require => User[$user],
+    require => User[$root_user],
   }
 
 
@@ -100,17 +100,17 @@ class verdi inherits hysds_base {
           "$verdi_dir/src",
           "$verdi_dir/etc"]:
     ensure  => directory,
-    owner   => $user,
-    group   => $group,
+    owner   => $root_user,
+    group   => $root_group,
     mode    => "0755",
-    require => User[$user],
+    require => User[$root_user],
   }
 
 
   file { "$verdi_dir/bin/verdid":
     ensure  => present,
-    owner   => $user,
-    group   => $group,
+    owner   => $root_user,
+    group   => $root_group,
     mode    => "0755",
     content => template('verdi/verdid'),
     require => File["$verdi_dir/bin"],
@@ -119,8 +119,8 @@ class verdi inherits hysds_base {
 
   file { "$verdi_dir/bin/start_verdi":
     ensure  => present,
-    owner   => $user,
-    group   => $group,
+    owner   => $root_user,
+    group   => $root_group,
     mode    => "0755",
     content => template('verdi/start_verdi'),
     require => File["$verdi_dir/bin"],
@@ -129,8 +129,8 @@ class verdi inherits hysds_base {
 
   file { "$verdi_dir/bin/stop_verdi":
     ensure  => present,
-    owner   => $user,
-    group   => $group,
+    owner   => $root_user,
+    group   => $root_group,
     mode    => "0755",
     content => template('verdi/stop_verdi'),
     require => File["$verdi_dir/bin"],

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -8,7 +8,7 @@ class verdi inherits hysds_base {
   # copy user files
   #####################################################
 
-  file { "/home/$user/.bash_profile":
+  file { "/$user/.bash_profile":
     ensure  => present,
     content => template('verdi/bash_profile'),
     owner   => $user,
@@ -29,7 +29,7 @@ class verdi inherits hysds_base {
   # verdi directory
   #####################################################
 
-  $verdi_dir = "/home/$user/verdi"
+  $verdi_dir = "/$user/verdi"
 
 
   #####################################################
@@ -76,7 +76,7 @@ class verdi inherits hysds_base {
   # files in ops home
   #####################################################
 
-  file { "/home/$user/install_hysds.sh":
+  file { "/$user/install_hysds.sh":
     ensure  => present,
     content => template('verdi/install_hysds.sh'),
     owner   => $user,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -8,24 +8,14 @@ class verdi inherits hysds_base {
   # copy user files
   #####################################################
 
-  file { "/$root_user/.bash_profile":
+  file { "/$user/.bash_profile":
     ensure  => present,
     content => template('verdi/bash_profile'),
-    owner   => $root_user,
-    group   => $root_group,
+    owner   => $user,
+    group   => $group,
     mode    => "0644",
-    require => User[$root_user],
+    require => User[$user],
   }
-
-  file { "/home/$ops_user/.bash_profile":
-    ensure  => present,
-    content => template('verdi/bash_profile'),
-    owner   => $ops_user,
-    group   => $ops_group,
-    mode    => "0644",
-    require => User[$ops_user],
-  }
-
 
   #####################################################
   # work directory
@@ -38,7 +28,7 @@ class verdi inherits hysds_base {
   # verdi directory
   #####################################################
 
-  $verdi_dir = "/$root_user/verdi"
+  $verdi_dir = "/$user/verdi"
 
   #####################################################
   # install packages
@@ -69,8 +59,8 @@ class verdi inherits hysds_base {
 
   file { "$verdi_dir/src/beefed-autoindex-open_in_new_win.tbz2":
     ensure  => file,
-    owner   => $root_user,
-    group   => $root_group,
+    owner   => $user,
+    group   => $group,
     mode    => "0644",
     source => 'puppet:///modules/verdi/beefed-autoindex-open_in_new_win.tbz2',
     require => [
@@ -84,13 +74,13 @@ class verdi inherits hysds_base {
   # files in ops home
   #####################################################
 
-  file { "/$root_user/install_hysds.sh":
+  file { "/$user/install_hysds.sh":
     ensure  => present,
     content => template('verdi/install_hysds.sh'),
-    owner   => $root_user,
-    group   => $root_group,
+    owner   => $user,
+    group   => $group,
     mode    => "0755",
-    require => User[$root_user],
+    require => User[$user],
   }
 
 
@@ -100,17 +90,17 @@ class verdi inherits hysds_base {
           "$verdi_dir/src",
           "$verdi_dir/etc"]:
     ensure  => directory,
-    owner   => $root_user,
-    group   => $root_group,
+    owner   => $user,
+    group   => $group,
     mode    => "0755",
-    require => User[$root_user],
+    require => User[$user],
   }
 
 
   file { "$verdi_dir/bin/verdid":
     ensure  => present,
-    owner   => $root_user,
-    group   => $root_group,
+    owner   => $user,
+    group   => $group,
     mode    => "0755",
     content => template('verdi/verdid'),
     require => File["$verdi_dir/bin"],
@@ -119,8 +109,8 @@ class verdi inherits hysds_base {
 
   file { "$verdi_dir/bin/start_verdi":
     ensure  => present,
-    owner   => $root_user,
-    group   => $root_group,
+    owner   => $user,
+    group   => $group,
     mode    => "0755",
     content => template('verdi/start_verdi'),
     require => File["$verdi_dir/bin"],
@@ -129,8 +119,8 @@ class verdi inherits hysds_base {
 
   file { "$verdi_dir/bin/stop_verdi":
     ensure  => present,
-    owner   => $root_user,
-    group   => $root_group,
+    owner   => $user,
+    group   => $group,
     mode    => "0755",
     content => template('verdi/stop_verdi'),
     require => File["$verdi_dir/bin"],


### PR DESCRIPTION
This PR updates the Dockerfile, entrypoint scripts, and Puppet Manifest files such that it supports the moving away from the OPS user that the Core containers would default to.

CircleCI passed when building containers under the HC-522-update tag:

![image](https://github.com/user-attachments/assets/2154a661-b3cb-4505-91e5-8506c4a28349)

Will need to remove the following kludges before merging:
- https://github.com/hysds/puppet-verdi/compare/docker...HC-522-update?expand=1#diff-f34da55ca08f1a30591d8b0b3e885bcc678537b2a9a4aadea4f190806b374ddcR2
- https://github.com/hysds/puppet-verdi/compare/docker...HC-522-update?expand=1#diff-f34da55ca08f1a30591d8b0b3e885bcc678537b2a9a4aadea4f190806b374ddcR11-R18
- https://github.com/hysds/puppet-verdi/compare/docker...HC-522-update?expand=1#diff-787aac437402bc45fd47d58638178fb65381efbae8abc8c7d2f1dbb112d9bdd6R2