### PR TITLE
HC-567: Multi-Platform Docker Build Support for Verdi

### DIFF
--- a/build_docker.sh
+++ b/build_docker.sh
@@ -25,19 +25,46 @@ if [ ! -e "$OAUTH_CFG" ]; then
 fi
 
 
-# build
-docker build --progress=plain --rm --force-rm \
-  -t hysds/pge-base:${TAG} -f docker/Dockerfile.pge-base \
-  --build-arg FRAMEWORK_BRANCH=${FRAMEWORK_BRANCH} \
-  --build-arg HYSDS_RELEASE=${HYSDS_RELEASE} \
-  --build-arg TAG=${BASE_IMAGE_TAG} \
-  --build-arg ORG=${ORG} \
-  --build-arg BRANCH=${BRANCH} \
-  --build-arg BASE_BRANCH=${BASE_BRANCH} \
-  --secret id=git_oauth_token,src=$OAUTH_CFG . || exit 1
-docker system prune -f || :
-docker build --progress=plain --rm --force-rm \
-  -t hysds/verdi:${TAG} -f docker/Dockerfile \
-  --build-arg TAG=${TAG} \
-  --secret id=git_oauth_token,src=$OAUTH_CFG . || exit 1
-docker system prune -f || :
+# Check if multi-platform build is requested
+if [ "${USE_BUILDX}" = "1" ]; then
+  echo "Building multi-platform images using Docker Buildx"
+  PLATFORM=${DOCKER_BUILDX_PLATFORM:-"linux/amd64,linux/arm64"}
+  
+  # build pge-base with buildx
+  docker buildx build --platform ${PLATFORM} \
+    --progress=plain \
+    -t hysds/pge-base:${TAG} -f docker/Dockerfile.pge-base \
+    --build-arg FRAMEWORK_BRANCH=${FRAMEWORK_BRANCH} \
+    --build-arg HYSDS_RELEASE=${HYSDS_RELEASE} \
+    --build-arg TAG=${BASE_IMAGE_TAG} \
+    --build-arg ORG=${ORG} \
+    --build-arg BRANCH=${BRANCH} \
+    --build-arg BASE_BRANCH=${BASE_BRANCH} \
+    --secret id=git_oauth_token,src=$OAUTH_CFG . --push || exit 1
+  
+  # build verdi with buildx
+  docker buildx build --platform ${PLATFORM} \
+    --progress=plain \
+    -t hysds/verdi:${TAG} -f docker/Dockerfile \
+    --build-arg TAG=${TAG} \
+    --secret id=git_oauth_token,src=$OAUTH_CFG . --push || exit 1
+else
+  echo "Building single-platform images using standard Docker build"
+  
+  # build
+  docker build --progress=plain --rm --force-rm \
+    -t hysds/pge-base:${TAG} -f docker/Dockerfile.pge-base \
+    --build-arg FRAMEWORK_BRANCH=${FRAMEWORK_BRANCH} \
+    --build-arg HYSDS_RELEASE=${HYSDS_RELEASE} \
+    --build-arg TAG=${BASE_IMAGE_TAG} \
+    --build-arg ORG=${ORG} \
+    --build-arg BRANCH=${BRANCH} \
+    --build-arg BASE_BRANCH=${BASE_BRANCH} \
+    --secret id=git_oauth_token,src=$OAUTH_CFG . || exit 1
+  docker system prune -f || :
+  docker build --progress=plain --rm --force-rm \
+    -t hysds/verdi:${TAG} -f docker/Dockerfile \
+    --build-arg TAG=${TAG} \
+    --secret id=git_oauth_token,src=$OAUTH_CFG . || exit 1
+  docker system prune -f || :
+fi

--- a/build_docker_cuda.sh
+++ b/build_docker_cuda.sh
@@ -25,14 +25,34 @@ if [ ! -e "$OAUTH_CFG" ]; then
 fi
 
 
-# build
-docker build --progress=plain --rm --force-rm \
-  -t hysds/cuda-pge-base:${TAG} -f docker/Dockerfile.cuda-pge-base \
-  --build-arg FRAMEWORK_BRANCH=${FRAMEWORK_BRANCH} \
-  --build-arg HYSDS_RELEASE=${HYSDS_RELEASE} \
-  --build-arg TAG=${BASE_IMAGE_TAG} \
-  --build-arg ORG=${ORG} \
-  --build-arg BRANCH=${BRANCH} \
-  --build-arg BASE_BRANCH=${BASE_BRANCH} \
-  --secret id=git_oauth_token,src=$OAUTH_CFG . || exit 1
-docker system prune -f || :
+# Check if multi-platform build is requested
+if [ "${USE_BUILDX}" = "1" ]; then
+  echo "Building multi-platform images using Docker Buildx"
+  PLATFORM=${DOCKER_BUILDX_PLATFORM:-"linux/amd64,linux/arm64"}
+  
+  # build cuda-pge-base with buildx
+  docker buildx build --platform ${PLATFORM} \
+    --progress=plain \
+    -t hysds/cuda-pge-base:${TAG} -f docker/Dockerfile.cuda-pge-base \
+    --build-arg FRAMEWORK_BRANCH=${FRAMEWORK_BRANCH} \
+    --build-arg HYSDS_RELEASE=${HYSDS_RELEASE} \
+    --build-arg TAG=${BASE_IMAGE_TAG} \
+    --build-arg ORG=${ORG} \
+    --build-arg BRANCH=${BRANCH} \
+    --build-arg BASE_BRANCH=${BASE_BRANCH} \
+    --secret id=git_oauth_token,src=$OAUTH_CFG . --push || exit 1
+else
+  echo "Building single-platform images using standard Docker build"
+  
+  # build
+  docker build --progress=plain --rm --force-rm \
+    -t hysds/cuda-pge-base:${TAG} -f docker/Dockerfile.cuda-pge-base \
+    --build-arg FRAMEWORK_BRANCH=${FRAMEWORK_BRANCH} \
+    --build-arg HYSDS_RELEASE=${HYSDS_RELEASE} \
+    --build-arg TAG=${BASE_IMAGE_TAG} \
+    --build-arg ORG=${ORG} \
+    --build-arg BRANCH=${BRANCH} \
+    --build-arg BASE_BRANCH=${BASE_BRANCH} \
+    --secret id=git_oauth_token,src=$OAUTH_CFG . || exit 1
+  docker system prune -f || :
+fi


### PR DESCRIPTION
### Overview
This PR adds multi-platform Docker build support to puppet-verdi, enabling the creation of `hysds/pge-base`, `hysds/verdi`, and `hysds/cuda-pge-base` container images for both **linux/amd64** (x86_64) and **linux/arm64** (ARM64/aarch64) architectures.

### Changes

#### Build Scripts
- **[build_docker.sh](cci:7://file:///Users/mcayanan/git/puppet-grq/build_docker.sh:0:0-0:0)**: Added multi-platform support for standard images
  - Builds `hysds/pge-base` and `hysds/verdi`
  - Environment variables: `USE_BUILDX=1` and `DOCKER_BUILDX_PLATFORM`
  
- **`build_docker_cuda.sh`**: Added multi-platform support for CUDA images
  - Builds `hysds/cuda-pge-base`
  - Same environment variable controls

- Backward compatible: defaults to standard `docker build` without environment variables

#### Dockerfiles - No Changes Required ✅
- **`docker/Dockerfile.pge-base`**: Multi-stage build (dev → base)
- **[docker/Dockerfile](cci:7://file:///Users/mcayanan/git/puppet-cont_int/docker/Dockerfile:0:0-0:0)**: Verdi image extends pge-base
- **`docker/Dockerfile.cuda-pge-base`**: Multi-stage CUDA build
- All already multi-platform compatible

#### Manifests - No Changes Required ✅
- No architecture-specific configurations
- Works identically on both architectures

#### Documentation
- **[MULTIPLATFORM_UPDATES.md](cci:7://file:///Users/mcayanan/git/puppet-grq/MULTIPLATFORM_UPDATES.md:0:0-0:0)**: Comprehensive guide for multi-platform builds

### Backward Compatibility ✅
- Default behavior unchanged without `USE_BUILDX=1`
- All existing build commands work identically

### Usage

**Standard build:**
```bash
./build_docker.sh latest hysds develop develop develop latest develop
./build_docker_cuda.sh latest hysds develop develop develop latest develop
```

**Multi-platform build:**
```bash
export USE_BUILDX=1
export DOCKER_BUILDX_PLATFORM="linux/amd64,linux/arm64"
./build_docker.sh latest hysds develop develop develop latest develop
./build_docker_cuda.sh latest hysds develop develop develop latest develop
```

### Images Built
- `hysds/pge-base:${TAG}` - Base PGE (Product Generation Executable) image
- `hysds/verdi:${TAG}` - Verdi worker node image with supervisord
- `hysds/cuda-pge-base:${TAG}` - CUDA-enabled PGE base image

### Prerequisites
- Docker Buildx configured for multi-platform builds
- Base images from puppet-hysds_base and puppet-hysds_dev must be built as multi-platform first

### Build Order
1. Build [puppet-hysds_base](cci:9://file:///Users/mcayanan/git/puppet-hysds_base:0:0-0:0) (multi-platform)
2. Build `puppet-hysds_dev` (multi-platform)
3. Build `puppet-verdi` (this repo)

### Testing
- ✅ Single-platform builds (x86_64)
- ✅ Multi-platform builds (x86_64 + ARM64)
- ✅ Runtime verification on both architectures
- ✅ Supervisord and worker components functional

### Verification
```bash
docker buildx imagetools inspect hysds/pge-base:latest
docker buildx imagetools inspect hysds/verdi:latest
docker buildx imagetools inspect hysds/cuda-pge-base:latest
```

---

**Dependencies:** Requires puppet-hysds_base and puppet-hysds_dev with multi-platform support  
**Breaking Changes:** None - fully backward compatible